### PR TITLE
feat: Implement GitHub-style completion heatmap

### DIFF
--- a/core/model/src/commonMain/kotlin/com/kakapo/model/date/MonthLabels.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/date/MonthLabels.kt
@@ -1,0 +1,5 @@
+package com.kakapo.model.date
+
+object MonthLabels {
+    val labels = listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+}

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/date/MonthModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/date/MonthModel.kt
@@ -1,4 +1,4 @@
-package org.kakapo.project.util.date.model
+package com.kakapo.model.date
 
 import kotlinx.datetime.LocalDate
 import kotlin.native.ObjCName

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/date/WeekDays.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/date/WeekDays.kt
@@ -1,4 +1,4 @@
-package org.kakapo.project.util.date.model
+package com.kakapo.model.date
 
 object WeekDays {
     val shortNames = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/date/WeekModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/date/WeekModel.kt
@@ -1,4 +1,4 @@
-package org.kakapo.project.util.date.model
+package com.kakapo.model.date
 
 import kotlinx.datetime.LocalDate
 import kotlin.native.ObjCName

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionDayModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionDayModel.kt
@@ -1,0 +1,12 @@
+package com.kakapo.model.heatmap
+
+import kotlinx.datetime.LocalDate
+import kotlin.native.ObjCName
+
+data class CompletionDayModel(
+    @ObjCName("dateKt")
+    val date: LocalDate,
+    val count: Int,
+    @ObjCName("levelKt")
+    val level: Int
+)

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionDayModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionDayModel.kt
@@ -3,10 +3,13 @@ package com.kakapo.model.heatmap
 import kotlinx.datetime.LocalDate
 import kotlin.native.ObjCName
 
-data class CompletionDayModel(
-    @ObjCName("dateKt")
-    val date: LocalDate,
-    val count: Int,
-    @ObjCName("levelKt")
-    val level: Int
-)
+sealed class CompletionDayModel {
+    data class Day(
+        @ObjCName("dateKt")
+        val date: LocalDate,
+        val count: Int,
+        @ObjCName("levelKt")
+        val level: Int
+    ): CompletionDayModel()
+    object Empty : CompletionDayModel()
+}

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionWeekModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionWeekModel.kt
@@ -1,0 +1,5 @@
+package com.kakapo.model.heatmap
+
+data class CompletionWeekModel(
+    val days: List<CompletionDayModel>
+)

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionYearModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/CompletionYearModel.kt
@@ -1,0 +1,7 @@
+package com.kakapo.model.heatmap
+
+data class CompletionYearModel(
+    val year: Int,
+    val weeks: List<CompletionWeekModel>,
+    val totalCompletions: Int,
+)

--- a/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/MonthInfoModel.kt
+++ b/core/model/src/commonMain/kotlin/com/kakapo/model/heatmap/MonthInfoModel.kt
@@ -1,0 +1,12 @@
+package com.kakapo.model.heatmap
+
+import kotlin.native.ObjCName
+
+data class MonthInfoModel(
+    @ObjCName("monthIndexKt")
+    val monthIndex: Int,
+    @ObjCName("widthKt")
+    val width: Float,
+    val startWeek: Int,
+    val endWeek: Int
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.0"
+agp = "8.11.1"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionDayView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionDayView.swift
@@ -9,12 +9,27 @@ struct CompletionDayView: View {
 	
 	var body: some View {
 		Rectangle()
-			.fill(color(day.level))
+			.fill(fillColor)
 			.frame(width: size, height: size)
 			.cornerRadius(2)
 			.onTapGesture {
-				onTap()
+				handleTap()
 			}
+	}
+	
+	private var fillColor: Color {
+		switch onEnum(of: day) {
+		case let .day(day): color(day.level)
+		case .empty: Color.clear
+		}
+	}
+	
+	private func handleTap() {
+		switch onEnum(of: day) {
+		case .day: onTap()
+		case .empty: print("do nothing")
+			
+		}
 	}
 	
 	private func color(_ level: Int) -> Color {

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionDayView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionDayView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import Shared
+
+struct CompletionDayView: View {
+	
+	let day: CompletionDayModel
+	let size: CGFloat
+	let onTap: () -> Void
+	
+	var body: some View {
+		Rectangle()
+			.fill(color(day.level))
+			.frame(width: size, height: size)
+			.cornerRadius(2)
+			.onTapGesture {
+				onTap()
+			}
+	}
+	
+	private func color(_ level: Int) -> Color {
+		switch level {
+		case 0: return Color.gray.opacity(0.1)
+		case 1: return Color.green.opacity(0.3)
+		case 2: return Color.green.opacity(0.5)
+		case 3: return Color.green.opacity(0.7)
+		case 4: return Color.green
+		default: return Color.gray.opacity(0.1)
+		}
+	}
+}

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
@@ -31,19 +31,19 @@ struct CompletionHeatMapView: View {
 	
 	@ViewBuilder
 	private func HeatMapGridView() -> some View {
-			ScrollView(.horizontal, showsIndicators: false) {
+		ScrollView(.horizontal, showsIndicators: false) {
+			HStack(alignment: .center, spacing: 4) {
+				WeekDayLabelsView()
 				VStack(alignment: .leading, spacing: 0) {
 					CompletionMonthLabel(
 						completionYear: completionYear,
 						daySize: daySize,
 						daySpacing: daySpacing
 					)
-					HStack(alignment: .top, spacing: 0) {
-						WeekDayLabelsView()
-						CompletionGridView()
-					}
+					CompletionGridView()
 				}
 			}
+		}
 	}
 	
 	@ViewBuilder
@@ -54,9 +54,10 @@ struct CompletionHeatMapView: View {
 				Text(label)
 					.font(Typography.titleSmall)
 					.foregroundStyle(ColorTheme.outline)
-					.frame(width: 18, height: daySize, alignment: .trailing)
+					.frame(width: 36, height: daySize, alignment: .trailing)
 			}
 		}
+		.padding(.top, daySize)
 	}
 	
 	@ViewBuilder
@@ -82,7 +83,7 @@ struct CompletionHeatMapView: View {
 		)
 	}
 	
-
+	
 	
 	private func calculateMonthWidthBy(index: Int) -> CGFloat {
 		let weekInMonth: CGFloat = 4.3

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
@@ -6,9 +6,9 @@ struct CompletionHeatMapView: View {
 	@State private var selectedDay: CompletionDayModel?
 	@State private var showTollTip: Bool = false
 	
-	private let daySize: CGFloat = 12
-	private let daySpacing: CGFloat = 2
-	private let monthLabels = MonthLabels.shared.labels
+	private let daySize: CGFloat = 16
+	private let daySpacing: CGFloat = 3
+	
 	private let weekDayLabels = WeekDays.shared.shortNames
 	
 	var body: some View {
@@ -31,37 +31,19 @@ struct CompletionHeatMapView: View {
 	
 	@ViewBuilder
 	private func HeatMapGridView() -> some View {
-		VStack(alignment: .leading, spacing: 0) {
-			MonthLabelsView()
-			ScrollView {
-				HStack(alignment: .top, spacing: 0) {
-					WeekDayLabelsView()
-					CompletionGridView()
+			ScrollView(.horizontal, showsIndicators: false) {
+				VStack(alignment: .leading, spacing: 0) {
+					CompletionMonthLabel(
+						completionYear: completionYear,
+						daySize: daySize,
+						daySpacing: daySpacing
+					)
+					HStack(alignment: .top, spacing: 0) {
+						WeekDayLabelsView()
+						CompletionGridView()
+					}
 				}
 			}
-			
-		}
-	}
-	
-	
-	@ViewBuilder
-	private func MonthLabelsView() -> some View {
-		HStack {
-			Rectangle()
-				.fill(ColorTheme.primary)
-				.frame(width: 20, height: 16)
-			
-			ForEach(0..<12, id: \.self) { index in
-				let monthWidth = calculateMonthWidthBy(index: index)
-				
-				if monthWidth > 0 {
-					Text(monthLabels[index])
-						.font(Typography.titleMedium)
-						.foregroundStyle(ColorTheme.outline)
-						.frame(width: monthWidth, alignment: .leading)
-				}
-			}
-		}
 	}
 	
 	@ViewBuilder
@@ -99,6 +81,8 @@ struct CompletionHeatMapView: View {
 				}
 		)
 	}
+	
+
 	
 	private func calculateMonthWidthBy(index: Int) -> CGFloat {
 		let weekInMonth: CGFloat = 4.3

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
@@ -3,7 +3,7 @@ import Shared
 
 struct CompletionHeatMapView: View {
 	let completionYear: CompletionYearModel
-	@State private var selectedDay: CompletionDayModel?
+	@State private var selectedDay: CompletionDayModel = .Empty()
 	@State private var showTollTip: Bool = false
 	
 	private let daySize: CGFloat = 16
@@ -93,6 +93,6 @@ struct CompletionHeatMapView: View {
 
 #Preview {
 	let dummyCompletion = CompletionYearStore()
-	let dummyData = dummyCompletion.generateCompletionYear(year: 2022, completionData: [:])
+	let dummyData = dummyCompletion.generateCompletionYear(year: 2021, completionData: [:])
 	CompletionHeatMapView(completionYear: dummyData)
 }

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionHeatMapView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import Shared
+
+struct CompletionHeatMapView: View {
+	let completionYear: CompletionYearModel
+	@State private var selectedDay: CompletionDayModel?
+	@State private var showTollTip: Bool = false
+	
+	private let daySize: CGFloat = 12
+	private let daySpacing: CGFloat = 2
+	private let monthLabels = MonthLabels.shared.labels
+	private let weekDayLabels = WeekDays.shared.shortNames
+	
+	var body: some View {
+		VStack(alignment: .leading, spacing: 16) {
+			HeaderView()
+			HeatMapGridView()
+			LegendView()
+		}
+	}
+	
+	@ViewBuilder
+	private func HeaderView() -> some View {
+		HStack {
+			Text("\(completionYear.totalCompletions) completions in \(completionYear.year)")
+				.font(Typography.titleLarge)
+			
+			Spacer()
+		}
+	}
+	
+	@ViewBuilder
+	private func HeatMapGridView() -> some View {
+		VStack(alignment: .leading, spacing: 0) {
+			MonthLabelsView()
+			ScrollView {
+				HStack(alignment: .top, spacing: 0) {
+					WeekDayLabelsView()
+					CompletionGridView()
+				}
+			}
+			
+		}
+	}
+	
+	
+	@ViewBuilder
+	private func MonthLabelsView() -> some View {
+		HStack {
+			Rectangle()
+				.fill(ColorTheme.primary)
+				.frame(width: 20, height: 16)
+			
+			ForEach(0..<12, id: \.self) { index in
+				let monthWidth = calculateMonthWidthBy(index: index)
+				
+				if monthWidth > 0 {
+					Text(monthLabels[index])
+						.font(Typography.titleMedium)
+						.foregroundStyle(ColorTheme.outline)
+						.frame(width: monthWidth, alignment: .leading)
+				}
+			}
+		}
+	}
+	
+	@ViewBuilder
+	private func WeekDayLabelsView() -> some View {
+		VStack(alignment: .trailing, spacing: daySpacing) {
+			ForEach(0..<7, id: \.self) { index in
+				let label = (index % 2 == 1) ? weekDayLabels[index] : ""
+				Text(label)
+					.font(Typography.titleSmall)
+					.foregroundStyle(ColorTheme.outline)
+					.frame(width: 18, height: daySize, alignment: .trailing)
+			}
+		}
+	}
+	
+	@ViewBuilder
+	private func CompletionGridView() -> some View {
+		HStack(alignment: .top, spacing: daySpacing) {
+			ForEach(Array(completionYear.weeks.enumerated()), id: \.offset) { _, week in
+				CompletionWeekView(
+					week: week,
+					daySize: daySize,
+					daySpacing: daySpacing,
+					onTapDay: { day in
+						selectedDay = day
+						showTollTip = true
+					}
+				)
+			}
+		}
+		.overlay(
+			ToolTipView(day: selectedDay, isVisible: showTollTip)
+				.onTapGesture {
+					showTollTip = false
+				}
+		)
+	}
+	
+	private func calculateMonthWidthBy(index: Int) -> CGFloat {
+		let weekInMonth: CGFloat = 4.3
+		return weekInMonth * (daySize + daySpacing)
+	}
+}
+
+#Preview {
+	let dummyCompletion = CompletionYearStore()
+	let dummyData = dummyCompletion.generateCompletionYear(year: 2022, completionData: [:])
+	CompletionHeatMapView(completionYear: dummyData)
+}

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionMonthLabel.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionMonthLabel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Shared
 
 struct CompletionMonthLabel: View {
+	
 	let completionYear: CompletionYearModel
 	let daySize: CGFloat
 	let daySpacing: CGFloat
@@ -14,7 +15,10 @@ struct CompletionMonthLabel: View {
 				.fill(Color.clear)
 				.frame(width: 20, height: 16)
 			
-			let monthPositions = calculateMonthPositions()
+			let monthPositions = completionYear.calculateMonthPositions(
+				daySize: Float(daySize),
+				daySpacing: Float(daySpacing)
+			)
 			
 			ForEach(Array(monthPositions.enumerated()), id: \.offset) { _, monthInfo in
 				if monthInfo.width > 0 {
@@ -25,61 +29,5 @@ struct CompletionMonthLabel: View {
 				}
 			}
 		}
-	}
-	
-	private func calculateMonthPositions() -> [MonthInfo] {
-		var monthInfos: [MonthInfo] = []
-		var currentMonth = -1
-		var monthStartWeek = 0
-		
-		for (weekIndex, week) in completionYear.weeks.enumerated() {
-			if let dayInCurrentYear = week.days.first(where: {
-				let calendar = Calendar.current
-				let year = calendar.component(.year, from: $0.date)
-				return year == completionYear.year
-			}) {
-				let calendar = Calendar.current
-				let month = calendar.component(.month, from: dayInCurrentYear.date) - 1
-				
-				if month != currentMonth {
-					if currentMonth != -1 {
-						let weekCount = weekIndex - monthStartWeek
-						let width = CGFloat(weekCount) * (daySize + daySpacing)
-						
-						monthInfos.append(MonthInfo(
-							monthIndex: currentMonth,
-							width: width,
-							startWeek: monthStartWeek,
-							endWeek: weekIndex - 1
-						))
-					}
-					
-					currentMonth = month
-					monthStartWeek = weekIndex
-				}
-			}
-		}
-		
-		if currentMonth != -1 {
-			let weekCount = completionYear.weeks.count - monthStartWeek
-			let width = CGFloat(weekCount) * (daySize + daySpacing)
-			
-			monthInfos.append(MonthInfo(
-				monthIndex: currentMonth,
-				width: width,
-				startWeek: monthStartWeek,
-				endWeek: completionYear.weeks.count - 1
-			))
-		}
-		
-		return monthInfos
-	}
-	
-	
-	private struct MonthInfo {
-		let monthIndex: Int
-		let width: CGFloat
-		let startWeek: Int
-		let endWeek: Int
 	}
 }

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionMonthLabel.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionMonthLabel.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import Shared
+
+struct CompletionMonthLabel: View {
+	let completionYear: CompletionYearModel
+	let daySize: CGFloat
+	let daySpacing: CGFloat
+	
+	private let monthLabels = MonthLabels.shared.labels
+	
+	var body: some View {
+		HStack(spacing: 0) {
+			Rectangle()
+				.fill(Color.clear)
+				.frame(width: 20, height: 16)
+			
+			let monthPositions = calculateMonthPositions()
+			
+			ForEach(Array(monthPositions.enumerated()), id: \.offset) { _, monthInfo in
+				if monthInfo.width > 0 {
+					Text(monthLabels[monthInfo.monthIndex])
+						.font(Typography.titleMedium)
+						.foregroundStyle(ColorTheme.outline)
+						.frame(width: monthInfo.width, alignment: .leading)
+				}
+			}
+		}
+	}
+	
+	private func calculateMonthPositions() -> [MonthInfo] {
+		var monthInfos: [MonthInfo] = []
+		var currentMonth = -1
+		var monthStartWeek = 0
+		
+		for (weekIndex, week) in completionYear.weeks.enumerated() {
+			if let dayInCurrentYear = week.days.first(where: {
+				let calendar = Calendar.current
+				let year = calendar.component(.year, from: $0.date)
+				return year == completionYear.year
+			}) {
+				let calendar = Calendar.current
+				let month = calendar.component(.month, from: dayInCurrentYear.date) - 1
+				
+				if month != currentMonth {
+					if currentMonth != -1 {
+						let weekCount = weekIndex - monthStartWeek
+						let width = CGFloat(weekCount) * (daySize + daySpacing)
+						
+						monthInfos.append(MonthInfo(
+							monthIndex: currentMonth,
+							width: width,
+							startWeek: monthStartWeek,
+							endWeek: weekIndex - 1
+						))
+					}
+					
+					currentMonth = month
+					monthStartWeek = weekIndex
+				}
+			}
+		}
+		
+		if currentMonth != -1 {
+			let weekCount = completionYear.weeks.count - monthStartWeek
+			let width = CGFloat(weekCount) * (daySize + daySpacing)
+			
+			monthInfos.append(MonthInfo(
+				monthIndex: currentMonth,
+				width: width,
+				startWeek: monthStartWeek,
+				endWeek: completionYear.weeks.count - 1
+			))
+		}
+		
+		return monthInfos
+	}
+	
+	
+	private struct MonthInfo {
+		let monthIndex: Int
+		let width: CGFloat
+		let startWeek: Int
+		let endWeek: Int
+	}
+}

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionWeekView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionWeekView.swift
@@ -10,11 +10,11 @@ struct CompletionWeekView: View {
 	
 	var body: some View {
 		VStack(spacing: daySpacing) {
-			ForEach(week.days, id: \.date) { day in
+			ForEach(Array(week.days.enumerated()), id: \.offset) { _, completionDay in
 				CompletionDayView(
-					day: day,
+					day: completionDay,
 					size: daySize,
-					onTap: { onTapDay(day) }
+					onTap: { onTapDay(completionDay) }
 				)
 			}
 		}

--- a/iosApp/iosApp/designSystem/component/heatmap/CompletionWeekView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/CompletionWeekView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import Shared
+
+struct CompletionWeekView: View {
+	
+	let week: CompletionWeekModel
+	let daySize: CGFloat
+	let daySpacing: CGFloat
+	let onTapDay: (CompletionDayModel) -> Void
+	
+	var body: some View {
+		VStack(spacing: daySpacing) {
+			ForEach(week.days, id: \.date) { day in
+				CompletionDayView(
+					day: day,
+					size: daySize,
+					onTap: { onTapDay(day) }
+				)
+			}
+		}
+	}
+}

--- a/iosApp/iosApp/designSystem/component/heatmap/LegendView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/LegendView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct LegendView: View {
+	var body: some View {
+		HStack {
+			Spacer()
+			Text("Less")
+				.font(Typography.titleMedium)
+			
+			HStack(spacing: 4) {
+				ForEach(0..<5, id: \.self) { level in
+					Rectangle()
+						.fill(color(level))
+						.frame(width: 10, height: 10)
+						.cornerRadius(2)
+				}
+			}
+			
+			Text("More")
+				.font(Typography.titleMedium)
+		}
+	}
+	
+	
+	private func color(_ level: Int) -> Color {
+		switch level {
+		case 0: return Color.gray.opacity(0.1)
+		case 1: return Color.green.opacity(0.3)
+		case 2: return Color.green.opacity(0.5)
+		case 3: return Color.green.opacity(0.7)
+		case 4: return Color.green
+		default: return Color.gray.opacity(0.1)
+		}
+	}
+}
+
+#Preview {
+	LegendView()
+}

--- a/iosApp/iosApp/designSystem/component/heatmap/ToolTipView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/ToolTipView.swift
@@ -2,16 +2,16 @@ import SwiftUI
 import Shared
 
 struct ToolTipView: View {
-	let day: CompletionDayModel?
+	let day: CompletionDayModel
 	let isVisible: Bool
 	
 	var body: some View {
-		if isVisible, let day = day {
+		if isVisible {
 			VStack(alignment: .leading, spacing: 4) {
-				Text(formatDate(day.date))
+				Text(date)
 					.font(Typography.titleMedium)
 				
-				Text("\(day.count) completed")
+				Text("\(count) completed")
 					.font(Typography.bodyMedium)
 					.foregroundColor(ColorTheme.outline)
 			}
@@ -21,6 +21,20 @@ struct ToolTipView: View {
 			.foregroundColor(.white)
 			.cornerRadius(6)
 			.transition(.opacity)
+		}
+	}
+	
+	private var date: String {
+		switch onEnum(of: day) {
+		case let .day(date): return formatDate(date.date)
+		case .empty: return "No data"
+		}
+	}
+	
+	private var count: String {
+		switch onEnum(of: day) {
+		case let .day(day): return"\(day.count)"
+		case .empty: return "0"
 		}
 	}
 	

--- a/iosApp/iosApp/designSystem/component/heatmap/ToolTipView.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/ToolTipView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import Shared
+
+struct ToolTipView: View {
+	let day: CompletionDayModel?
+	let isVisible: Bool
+	
+	var body: some View {
+		if isVisible, let day = day {
+			VStack(alignment: .leading, spacing: 4) {
+				Text(formatDate(day.date))
+					.font(Typography.titleMedium)
+				
+				Text("\(day.count) completed")
+					.font(Typography.bodyMedium)
+					.foregroundColor(ColorTheme.outline)
+			}
+			.padding(.horizontal, 8)
+			.padding(.vertical, 6)
+			.background(Color.black.opacity(0.8))
+			.foregroundColor(.white)
+			.cornerRadius(6)
+			.transition(.opacity)
+		}
+	}
+	
+	private func formatDate(_ date: Date) -> String {
+		let formatter = DateFormatter()
+		formatter.dateStyle = .medium
+		return formatter.string(from: date)
+	}
+}
+

--- a/iosApp/iosApp/designSystem/component/heatmap/util/HeatMapExtension.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/util/HeatMapExtension.swift
@@ -9,3 +9,12 @@ extension CompletionDayModel {
 		Int(self.levelKt)
 	}
 }
+
+extension MonthInfoModel {
+	public var monthIndex: Int {
+		Int(self.monthIndexKt)
+	}
+	public var width: CGFloat {
+		CGFloat(self.widthKt)
+	}
+}

--- a/iosApp/iosApp/designSystem/component/heatmap/util/HeatMapExtension.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/util/HeatMapExtension.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Shared
 
-extension CompletionDayModel {
+extension CompletionDayModel.Day {
 	public var date: Date {
 		self.dateKt.toDate()
 	}

--- a/iosApp/iosApp/designSystem/component/heatmap/util/HeatMapExtension.swift
+++ b/iosApp/iosApp/designSystem/component/heatmap/util/HeatMapExtension.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Shared
+
+extension CompletionDayModel {
+	public var date: Date {
+		self.dateKt.toDate()
+	}
+	public var level: Int {
+		Int(self.levelKt)
+	}
+}

--- a/iosApp/iosApp/screen/habitsMenu/goodHabit/GoodHabitScreen.swift
+++ b/iosApp/iosApp/screen/habitsMenu/goodHabit/GoodHabitScreen.swift
@@ -8,6 +8,8 @@ struct GoodHabitScreen: View {
 	@State private var dummyData: [Double] = [
 		0.3, 0.6, 0.8, 0.2, 0.5, 0.7, 1
 	]
+	private let dummyCompletionYear = CompletionYearStore()
+	
 	
 	var body: some View {
 		VStack {
@@ -33,12 +35,13 @@ struct GoodHabitScreen: View {
 	
 	@ViewBuilder
 	private func ContentView() -> some View {
+		let data = dummyCompletionYear.generateCompletionYear(year: 2025, completionData: [:])
 		ScrollView {
 			VStack(alignment: .leading, spacing: 16) {
 				TitleComponentView()
 				GoodHabitMetricsView(habit: state.goodHabit)
 				TitleDateComponentView()
-				CalendarMonthView()
+				CompletionHeatMapView(completionYear: data)
 				WeekChartView(data: dummyData)
 			}
 			.padding(.horizontal, 16)

--- a/shared/src/commonMain/kotlin/org/kakapo/project/util/date/calendar/CalendarStore.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/util/date/calendar/CalendarStore.kt
@@ -13,10 +13,9 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.number
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import org.kakapo.project.util.date.model.DayState
-import org.kakapo.project.util.date.model.MonthModel
-import org.kakapo.project.util.date.model.WeekModel
-import org.kakapo.project.util.date.model.WeekOfMonthModel
+import com.kakapo.model.date.DayState
+import com.kakapo.model.date.MonthModel
+import com.kakapo.model.date.WeekOfMonthModel
 import org.kakapo.project.util.date.util.startOfWeek
 import kotlin.native.ObjCName
 import kotlin.time.Clock

--- a/shared/src/commonMain/kotlin/org/kakapo/project/util/date/horizontalCalendar/HorizontalCalendarStore.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/util/date/horizontalCalendar/HorizontalCalendarStore.kt
@@ -1,6 +1,5 @@
 package org.kakapo.project.util.date.horizontalCalendar
 
-import co.touchlab.kermit.Logger
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
 import kotlinx.coroutines.CoroutineDispatcher
@@ -19,11 +18,10 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import org.kakapo.project.util.date.model.WeekModel
+import com.kakapo.model.date.WeekModel
 import org.kakapo.project.util.date.util.startOfWeek
 import kotlin.native.ObjCName
 import kotlin.time.Clock

--- a/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearCalculator.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearCalculator.kt
@@ -1,7 +1,9 @@
 package org.kakapo.project.util.heatmap
 
+import com.kakapo.model.heatmap.CompletionDayModel
 import com.kakapo.model.heatmap.CompletionYearModel
 import com.kakapo.model.heatmap.MonthInfoModel
+import kotlinx.datetime.number
 
 fun CompletionYearModel.calculateMonthPositions(
     daySize: Float,
@@ -24,8 +26,9 @@ fun calculateMonthTransitions(
         .withIndex()
         .mapNotNull { (weekIndex, week) ->
             week.days
+                .filterIsInstance<CompletionDayModel.Day>()
                 .firstOrNull { it.date.year == completionYear.year }
-                ?.let { day -> weekIndex to (day.date.monthNumber - 1) }
+                ?.let { day -> weekIndex to (day.date.month.number - 1) }
         }
         .distinctBy { it.second }
         .map { (weekIndex, month) -> Triple(weekIndex, month, month) }

--- a/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearCalculator.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearCalculator.kt
@@ -2,54 +2,63 @@ package org.kakapo.project.util.heatmap
 
 import com.kakapo.model.heatmap.CompletionYearModel
 import com.kakapo.model.heatmap.MonthInfoModel
-import kotlinx.datetime.number
+
+fun CompletionYearModel.calculateMonthPositions(
+    daySize: Float,
+    daySpacing: Float
+): List<MonthInfoModel> = calculateMonthPositions(this, daySize, daySpacing)
 
 fun calculateMonthPositions(
     completionYear: CompletionYearModel,
     daySize: Float,
     daySpacing: Float
 ): List<MonthInfoModel> {
+    val transitions = calculateMonthTransitions(completionYear)
+    return transitions.transformItToMonthInfoWith(completionYear, daySize, daySpacing)
+}
 
-    val monthTransitions = completionYear.weeks
+fun calculateMonthTransitions(
+    completionYear: CompletionYearModel
+): List<Triple<Int, Int, Int>> {
+    return completionYear.weeks
         .withIndex()
         .mapNotNull { (weekIndex, week) ->
             week.days
                 .firstOrNull { it.date.year == completionYear.year }
-                ?.let { day -> weekIndex to (day.date.month.number - 1) }
+                ?.let { day -> weekIndex to (day.date.monthNumber - 1) }
         }
         .distinctBy { it.second }
         .map { (weekIndex, month) -> Triple(weekIndex, month, month) }
+}
 
-    return monthTransitions
-        .zipWithNext { current, next ->
-            val (startWeek, monthIndex, _) = current
-            val (endWeek, _, _) = next
-            val weekCount = endWeek - startWeek
+fun List<Triple<Int, Int, Int>>.transformItToMonthInfoWith(
+    completionYear: CompletionYearModel,
+    daySize: Float,
+    daySpacing: Float
+): List<MonthInfoModel> {
+    return zipWithNext { current, next ->
+        val (startWeek, monthIndex, _) = current
+        val (endWeek, _, _) = next
+        val weekCount = endWeek - startWeek
+        val width = weekCount.toFloat() * (daySize + daySpacing)
+
+        MonthInfoModel(
+            monthIndex = monthIndex,
+            width = width,
+            startWeek = startWeek,
+            endWeek = endWeek - 1
+        )
+    }.let { monthInfos ->
+        this.lastOrNull()?.let { (startWeek, monthIndex, _) ->
+            val weekCount = completionYear.weeks.size - startWeek
             val width = weekCount.toFloat() * (daySize + daySpacing)
 
-            MonthInfoModel(
+            monthInfos + MonthInfoModel(
                 monthIndex = monthIndex,
                 width = width,
                 startWeek = startWeek,
-                endWeek = endWeek - 1
+                endWeek = completionYear.weeks.size - 1
             )
-        }
-        .let { monthInfos ->
-            monthTransitions.lastOrNull()?.let { (startWeek, monthIndex, _) ->
-                val weekCount = completionYear.weeks.size - startWeek
-                val width = weekCount.toFloat() * (daySize + daySpacing)
-
-                monthInfos + MonthInfoModel(
-                    monthIndex = monthIndex,
-                    width = width,
-                    startWeek = startWeek,
-                    endWeek = completionYear.weeks.size - 1
-                )
-            } ?: monthInfos
-        }
+        } ?: monthInfos
+    }
 }
-
-fun CompletionYearModel.calculateMonthPositions(
-    daySize: Float,
-    daySpacing: Float
-): List<MonthInfoModel> = calculateMonthPositions(this, daySize, daySpacing)

--- a/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearCalculator.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearCalculator.kt
@@ -1,0 +1,55 @@
+package org.kakapo.project.util.heatmap
+
+import com.kakapo.model.heatmap.CompletionYearModel
+import com.kakapo.model.heatmap.MonthInfoModel
+import kotlinx.datetime.number
+
+fun calculateMonthPositions(
+    completionYear: CompletionYearModel,
+    daySize: Float,
+    daySpacing: Float
+): List<MonthInfoModel> {
+
+    val monthTransitions = completionYear.weeks
+        .withIndex()
+        .mapNotNull { (weekIndex, week) ->
+            week.days
+                .firstOrNull { it.date.year == completionYear.year }
+                ?.let { day -> weekIndex to (day.date.month.number - 1) }
+        }
+        .distinctBy { it.second }
+        .map { (weekIndex, month) -> Triple(weekIndex, month, month) }
+
+    return monthTransitions
+        .zipWithNext { current, next ->
+            val (startWeek, monthIndex, _) = current
+            val (endWeek, _, _) = next
+            val weekCount = endWeek - startWeek
+            val width = weekCount.toFloat() * (daySize + daySpacing)
+
+            MonthInfoModel(
+                monthIndex = monthIndex,
+                width = width,
+                startWeek = startWeek,
+                endWeek = endWeek - 1
+            )
+        }
+        .let { monthInfos ->
+            monthTransitions.lastOrNull()?.let { (startWeek, monthIndex, _) ->
+                val weekCount = completionYear.weeks.size - startWeek
+                val width = weekCount.toFloat() * (daySize + daySpacing)
+
+                monthInfos + MonthInfoModel(
+                    monthIndex = monthIndex,
+                    width = width,
+                    startWeek = startWeek,
+                    endWeek = completionYear.weeks.size - 1
+                )
+            } ?: monthInfos
+        }
+}
+
+fun CompletionYearModel.calculateMonthPositions(
+    daySize: Float,
+    daySpacing: Float
+): List<MonthInfoModel> = calculateMonthPositions(this, daySize, daySpacing)

--- a/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearStore.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/util/heatmap/CompletionYearStore.kt
@@ -1,0 +1,85 @@
+package org.kakapo.project.util.heatmap
+
+import com.kakapo.model.heatmap.CompletionDayModel
+import com.kakapo.model.heatmap.CompletionWeekModel
+import com.kakapo.model.heatmap.CompletionYearModel
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+
+class CompletionYearStore {
+
+    fun generateCompletionYear(
+        year: Int,
+        completionData: Map<LocalDate, Int>
+    ): CompletionYearModel {
+        val startDate = getYearStartDate(year)
+        val endDate = getYearEndDate(year)
+
+        val weeks = generateWeeks(startDate, endDate, completionData)
+        val totalCompletions = completionData.values.sum()
+
+        return CompletionYearModel(
+            year = year,
+            weeks = weeks,
+            totalCompletions = totalCompletions
+        )
+    }
+
+    private fun generateWeeks(
+        startDate: LocalDate,
+        endDate: LocalDate,
+        completionData: Map<LocalDate, Int>
+    ): List<CompletionWeekModel> {
+        return generateSequence(startDate) { currentDate ->
+            currentDate.plus(7, DateTimeUnit.DAY).takeIf { it <= endDate }
+        }.map { weekStart ->
+            val weekDays = generateWeekDays(weekStart, endDate, completionData)
+            CompletionWeekModel(days = weekDays)
+        }.toList()
+    }
+
+    private fun generateWeekDays(
+        weekStart: LocalDate,
+        yearEnd: LocalDate,
+        completionData: Map<LocalDate, Int>
+    ): List<CompletionDayModel> {
+        return (0..6)
+            .map { dayOffset -> weekStart.plus(dayOffset, DateTimeUnit.DAY) }
+            .filter { currentDate -> currentDate <= yearEnd }
+            .map { currentDate ->
+                val count = completionData[currentDate] ?: 0
+                CompletionDayModel(
+                    date = currentDate,
+                    count = count,
+                    level = calculateLevel(count)
+                )
+            }
+    }
+
+    private fun getYearStartDate(year: Int): LocalDate {
+        val januaryFirst = LocalDate(year, 1, 1)
+        val dayOfWeek = januaryFirst.dayOfWeek.isoDayNumber % 7
+
+        return januaryFirst.minus(dayOfWeek, DateTimeUnit.DAY)
+    }
+
+    private fun getYearEndDate(year: Int): LocalDate {
+        val decemberLast = LocalDate(year, 12, 31)
+        val dayOfWeek = decemberLast.dayOfWeek.isoDayNumber % 7
+
+        return decemberLast.plus(6 - dayOfWeek, DateTimeUnit.DAY)
+    }
+
+    private fun calculateLevel(count: Int): Int {
+        return when {
+            count == 0 -> 0
+            count <= 3 -> 1
+            count <= 6 -> 2
+            count <= 9 -> 3
+            else -> 4
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a completion heatmap visualization, similar to GitHub's contribution graph, to display habit completion data over a year.

**Shared Module - Heatmap Logic:**

- **`CompletionYearStore.kt` (New File):**
    - `generateCompletionYear(year: Int, completionData: Map<LocalDate, Int>)`: - Calculates the start and end dates for the given year, adjusting to full weeks. - Generates a list of `CompletionWeekModel` for the year. - Calculates the total number of completions. - Returns a `CompletionYearModel`.
    - `generateWeeks()`: Creates `CompletionWeekModel` instances by iterating through the weeks of the year.
    - `generateWeekDays()`: Creates `CompletionDayModel` instances for each day in a week, including completion count and level.
    - `getYearStartDate()` / `getYearEndDate()`: Helper functions to determine the exact start/end dates for the heatmap display, ensuring full weeks are shown.
    - `calculateLevel(count: Int)`: Determines the intensity level (0-4) based on the completion count for a day.

**Core Model - New Data Models for Heatmap:**

- **`CompletionYearModel.kt` (New File):** Data class representing a year's completion data, including `year`, `weeks` (list of `CompletionWeekModel`), and `totalCompletions`.
- **`CompletionWeekModel.kt` (New File):** Data class representing a week's completion data, containing a list of `CompletionDayModel`.
- **`CompletionDayModel.kt` (New File):** Data class representing a single day's completion, including `date`, `count`, and `level`. `@ObjCName` annotations added for Swift interoperability.
- **`MonthLabels.kt` (New File):** Object providing a list of short month names (`"Jan"`, `"Feb"`, etc.).

**iOS App - Heatmap UI Components:**

- **`GoodHabitScreen.swift`:**
    - Replaced `CalendarMonthView` with the new `CompletionHeatMapView`.
    - Added `dummyCompletionYear` to generate sample data for the heatmap.
- **`CompletionHeatMapView.swift` (New File):**
    - Main view for displaying the heatmap.
    - Manages `selectedDay` and `showTollTip` state.
    - `HeaderView()`: Displays total completions and the year.
    - `HeatMapGridView()`: Arranges month labels, weekday labels, and the completion grid.
    - `MonthLabelsView()`: Displays month labels above the grid.
    - `WeekDayLabelsView()`: Displays weekday labels (e.g., "Mon", "Wed") vertically.
    - `CompletionGridView()`: Displays the actual heatmap cells using `CompletionWeekView`. Shows a `ToolTipView` on cell tap.
    - `calculateMonthWidthBy()`: Helper to calculate the width for month labels.
- **`CompletionWeekView.swift` (New File):**
    - Renders a vertical column of `CompletionDayView` for a single week.
- **`CompletionDayView.swift` (New File):**
    - Renders a single day cell in the heatmap.
    - Color is determined by the `level` of completion.
    - Handles tap gestures to show tooltips.
- **`ToolTipView.swift` (New File):**
    - Displays the date and completion count when a day cell is tapped.
- **`LegendView.swift` (New File):**
    - Displays a color legend for the heatmap (Less to More).
- **`util/HeatMapExtension.swift` (New File):**
    - Adds Swift convenience accessors for `date` and `level` on `CompletionDayModel`.

**Refactoring - Model File Moves:**

- `WeekModel.kt` moved from `shared/src/commonMain/kotlin/org/kakapo/project/util/date/model` to `core/model/src/commonMain/kotlin/com/kakapo/model/date`.
- `WeekDays.kt` moved from `shared/src/commonMain/kotlin/org/kakapo/project/util/date/model` to `core/model/src/commonMain/kotlin/com/kakapo/model/date`.
- `MonthModel.kt` moved from `shared/src/commonMain/kotlin/org/kakapo/project/util/date/model` to `core/model/src/commonMain/kotlin/com/kakapo/model/date`.

**Shared Module - Minor Changes:**

- **`HorizontalCalendarStore.kt`:** Removed unused `Logger` import and `isoDayNumber` import. Corrected `WeekModel` import path.
- **`CalendarStore.kt`:** Corrected import paths for `DayState`, `MonthModel`, and `WeekOfMonthModel`.