### PR TITLE
Fixing Bug: GoodHabit metric get invalid calculation

### DIFF
--- a/core/data/src/commonMain/kotlin/com/kakapo/data/model/habit/HabitCheckMapper.kt
+++ b/core/data/src/commonMain/kotlin/com/kakapo/data/model/habit/HabitCheckMapper.kt
@@ -24,6 +24,7 @@ fun HabitCheckEntity.toHabitCheckModel(): HabitCheckModel {
     return HabitCheckModel(
         id = id,
         date = date,
-        isCompleted = isCompleted
+        isCompleted = isCompleted,
+        completionCount = completionCount
     )
 }

--- a/core/database/src/commonMain/kotlin/com/kakapo/database/datasource/implementation/habit/HabitCheckLocalDatasourceImpl.kt
+++ b/core/database/src/commonMain/kotlin/com/kakapo/database/datasource/implementation/habit/HabitCheckLocalDatasourceImpl.kt
@@ -6,7 +6,6 @@ import app.cash.sqldelight.db.SqlDriver
 import com.kakapo.Database
 import com.kakapo.GetHabitCheckByHabitId
 import com.kakapo.common.asLong
-import com.kakapo.common.util.currentTime
 import com.kakapo.database.datasource.base.habits.HabitCheckLocalDatasource
 import com.kakapo.database.model.habit.HabitCheckEntity
 import com.kakapo.database.model.habit.toHabitCheckEntity

--- a/core/database/src/commonMain/kotlin/com/kakapo/database/model/habit/HabitCheckEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/kakapo/database/model/habit/HabitCheckEntity.kt
@@ -1,19 +1,20 @@
 package com.kakapo.database.model.habit
 
+import co.touchlab.kermit.Logger
 import com.kakapo.GetHabitCheckByHabitId
+import com.kakapo.HabitCheckTable
 
 data class HabitCheckEntity(
     val id: Long = 0,
     val habitId: Long = 0,
     val date: Long = 0,
     val timeStamp: Long = 0,
-    val completionCount: Long = 0,
+    val completionCount: Long = 1,
     val isCompleted: Boolean = false
 )
 
 fun GetHabitCheckByHabitId.toHabitCheckEntity(): HabitCheckEntity {
     return HabitCheckEntity(
-        id = id,
         habitId = habitId,
         date = date,
         timeStamp = lastEntry ?: 0,

--- a/core/domain/src/commonMain/kotlin/com/kakapo/domain/useCase/logic/GoodHabitDetailLogic.kt
+++ b/core/domain/src/commonMain/kotlin/com/kakapo/domain/useCase/logic/GoodHabitDetailLogic.kt
@@ -1,5 +1,6 @@
 package com.kakapo.domain.useCase.logic
 
+import co.touchlab.kermit.Logger
 import com.kakapo.common.util.dayToDateWith
 import com.kakapo.domain.model.GoodHabitUseCaseParam
 import com.kakapo.model.habit.CompletionType

--- a/shared/src/commonMain/kotlin/org/kakapo/project/presentation/habitMenu/goodHabit/GoodHabitViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/presentation/habitMenu/goodHabit/GoodHabitViewModel.kt
@@ -52,6 +52,7 @@ class GoodHabitViewModel(
     private fun loadGoodHabitBy(habitId: Long) = viewModelScope.launch {
         val param = goodHabitParamFactory(habitId)
         val onSuccess: (GoodHabitModel) -> Unit = { goodHabit ->
+            Logger.d("loadGoodHabit $goodHabit")
             _uiState.update { it.copy(goodHabit = goodHabit) }
             weeksStore.initData(startEpochDay = goodHabit.startDate, currentEpochDay = currentDay)
             monthsStore.initData(startEpochDay = goodHabit.startDate, currentEpochDay = currentDay)

--- a/shared/src/commonMain/kotlin/org/kakapo/project/presentation/habitMenu/habits/HabitsViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/kakapo/project/presentation/habitMenu/habits/HabitsViewModel.kt
@@ -53,7 +53,7 @@ class HabitsViewModel(
     }
 
     private fun checkedGoodHabitBy(habitId: Long) = viewModelScope.launch {
-        val param = HabitCheckParam(habitId = habitId)
+        val param = HabitCheckParam(habitId = habitId, isCompleted = true)
         val onSuccess: (Unit) -> Unit = {
             loadHabitsToday()
         }


### PR DESCRIPTION
This commit updates the default `completionCount` for a `HabitCheckEntity` to 1. It also removes the `id` from `toHabitCheckEntity()` as the database typically generates it.

**Core - Database:**
- **`HabitCheckEntity.kt`:**
    - Default `completionCount` is now `1`.
    - `toHabitCheckEntity()`: Removed assignment of `id`. The `HabitCheckTable` from SQLDelight generates the `id`.

**Core - Data:**
- **`HabitCheckMapper.kt`:**
    - `toHabitCheckModel()` now includes `completionCount`.

**Shared Module:**
- **`HabitsViewModel.kt`:**
    - `checkedGoodHabitBy()`: The `HabitCheckParam` is now initialized with `isCompleted = true`.
- **`GoodHabitViewModel.kt`:**
    - Added logging for `goodHabit` in `loadGoodHabitBy`.

**Core - Domain:**
- **`GoodHabitDetailLogic.kt`:** Added Kermit logger.

**Core - Database (Implementation):**
- **`HabitCheckLocalDatasourceImpl.kt`:** Removed unused import `com.kakapo.common.util.currentTime`.